### PR TITLE
Faster/Simpler Hash function

### DIFF
--- a/lib/Cuckoo/Filter.pm
+++ b/lib/Cuckoo/Filter.pm
@@ -40,7 +40,7 @@ sub _fingerprint {
 
 # djb hash
 sub _hash {
-    my ($self, $str) = @_;
+    my $str = shift;
     my @bytes = unpack 'C*', $str;
     my $h = 5381;
     for my $i (@bytes) {
@@ -52,8 +52,8 @@ sub _hash {
 sub lookup {
     my ($self, $item) = @_;
     my $fp = $self->_fingerprint($item);
-    my $idx1 = $self->_hash($item) % $self->{bucket_size};
-    my $idx2 = ($idx1 ^ $self->_hash($fp)) % $self->{bucket_size};
+    my $idx1 = _hash($item) % $self->{bucket_size};
+    my $idx2 = ($idx1 ^ _hash($fp)) % $self->{bucket_size};
 
     return defined $self->{buckets}[$idx1] || $self->{buckets}[$idx2];
 }
@@ -62,8 +62,8 @@ sub insert {
     my ($self, $item) = @_;
     return 0 if $self->lookup($item);
     my $fp = $self->_fingerprint($item);
-    my $idx1 = $self->_hash($item) % $self->{bucket_size};
-    my $idx2 = ($idx1 ^ $self->_hash($fp)) % $self->{bucket_size};
+    my $idx1 = _hash($item) % $self->{bucket_size};
+    my $idx2 = ($idx1 ^ _hash($fp)) % $self->{bucket_size};
     for my $index ($idx1, $idx2) {
         if (! defined $self->{buckets}[$index]) {
             $self->{buckets}[$index] = $item;
@@ -79,7 +79,7 @@ sub insert {
             $self->{buckets}[$index] = $fp;
             $f;
         };
-        $index = ($idx1 ^ $self->_hash($fp)) % $self->{bucket_size};
+        $index = ($idx1 ^ _hash($fp)) % $self->{bucket_size};
 
         if (! defined $self->{buckets}[$index]) {
             $self->{buckets}[$index] = $fp;
@@ -94,8 +94,8 @@ sub insert {
 sub delete {
     my ($self, $item) = @_;
     my $fp = $self->_fingerprint($item);
-    my $idx1 = $self->_hash($item) % $self->{bucket_size};
-    my $idx2 = ($idx1 ^ $self->_hash($fp)) % $self->{bucket_size};
+    my $idx1 = _hash($item) % $self->{bucket_size};
+    my $idx2 = ($idx1 ^ _hash($fp)) % $self->{bucket_size};
     for my $index ($idx1, $idx2) {
         if (defined $self->{buckets}[$index]) {
             delete $self->{buckets}[$index];

--- a/lib/Cuckoo/Filter.pm
+++ b/lib/Cuckoo/Filter.pm
@@ -38,18 +38,15 @@ sub _fingerprint {
     return substr($digest, 0, $self->{fingerprint_size}-1);
 }
 
+# djb hash
 sub _hash {
-    my ($self, $item) = @_;
-
-    # djb hash
+    my ($self, $str) = @_;
+    my @bytes = unpack 'C*', $str;
     my $h = 5381;
-    for (my $i = 0; $i < length $item; $i++) {
-        my $prefix = $i > 0 ? "x${i} " : '';
-        my $t = unpack("${prefix}C1", $item);
-        $h = (($h << 5) + $h) + $t;
+    for my $i (@bytes) {
+        $h = (($h << 5) + $h) + $i;
     }
-
-    return $h;
+    $h;
 }
 
 sub lookup {


### PR DESCRIPTION
* Call `unpack` once
* Define `_hash` function as a **function**

# Benchmark

```perl
#!/usr/bin/env perl
use strict;
use warnings;

use Benchmark qw(:all);

my $count = 100_000;

my $str = 'Hello, world!' x 32;

sub orig {
    my ($item) = @_;

    # djb hash
    my $h = 5381;
    for (my $i = 0; $i < length $item; $i++) {
        my $prefix = $i > 0 ? "x${i} " : '';
        my $t = unpack("${prefix}C1", $item);
        $h = (($h << 5) + $h) + $t;
    }

    return $h;
}

sub hash {
    my ($str) = @_;
    my @bytes = unpack 'C*', $str;
    my $h = 5381;
    for my $i (@bytes) {
        $h = (($h << 5) + $h) + $i;
    }
    $h;
}

cmpthese(timethese($count, {
    'orig' => sub {
        orig($str);
    },
    'new' => sub {
        hash($str);
    },
}));

__END__
Benchmark: timing 100000 iterations of new, orig...
       new:  8 wallclock secs ( 7.70 usr +  0.01 sys =  7.71 CPU) @ 12970.17/s (n=100000)
      orig: 21 wallclock secs (21.16 usr +  0.03 sys = 21.19 CPU) @ 4719.21/s (n=100000)
        Rate orig  new
orig  4719/s   -- -64%
new  12970/s 175%   --
```